### PR TITLE
Adds support for Laravel ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.2",
+        "laravel/helpers": "^1.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Adds support for Laravel ^6.0

* Use the new [Laravel helpers package](https://github.com/laravel/helpers)
* Update minimum `php` version required to `^7.2`